### PR TITLE
Correccion de errores

### DIFF
--- a/module/AERSA/src/Application/Flujoefectivo/Controller/CuentabancariaController.php
+++ b/module/AERSA/src/Application/Flujoefectivo/Controller/CuentabancariaController.php
@@ -82,6 +82,7 @@ class CuentabancariaController extends AbstractActionController {
             $form->setData($cuentabancaria->toArray(\BasePeer::TYPE_FIELDNAME));
             
             $flujoefectivo = \FlujoefectivoQuery::create()->filterByIdcuentabancaria($cuentabancaria->getIdcuentabancaria())->find();
+            $saldoproveedor = \AbonoproveedordetalleQuery::create()->filterByIdcuentabancaria($cuentabancaria->getIdcuentabancaria())->find();
             
             $view_model = new ViewModel();
             $view_model->setTemplate('/application/flujoefectivo/cuentabancaria/editar');
@@ -90,6 +91,7 @@ class CuentabancariaController extends AbstractActionController {
                 'cuentabancaria' => $cuentabancaria,
                 'messages' => $this->flashMessenger(),
                 'flujoefectivo' => $flujoefectivo,
+                'saldoproveedor' => $saldoproveedor,
             ));
             return $view_model;
         } else {

--- a/module/AERSA/view/application/flujoefectivo/cuentabancaria/editar.phtml
+++ b/module/AERSA/view/application/flujoefectivo/cuentabancaria/editar.phtml
@@ -95,6 +95,21 @@
                             <td><?php echo ($entity->getFlujoefectivoComprobante() != null) ? '<a target="_blank" href="' . $entity->getFlujoefectivoComprobante() . '"><i class="fa fa-file"></i></a>' : " "; ?></td>
                         </tr>                            
                     <?php endforeach; ?>
+                    <?php
+                    $entity = new Abonoproveedordetalle();
+                    foreach ($saldoproveedor as $entity) :
+                        $cobrado = ($entity->getAbonoproveedordetalleMediodepago() == 'cheque' && $entity->getAbonoproveedordetalleChequecirculacion()) ? "Cobrado" : "No cobrado";
+                        $class = ($entity->getAbonoproveedordetalleMediodepago() == 'cheque' && $entity->getAbonoproveedordetalleChequecirculacion()) ? "info" : "danger";
+                        ?>
+                        <tr id="<?php echo $entity->getIdabonoproveedordetalle() ?>">
+                            <td><?php echo $entity->getAbonoproveedordetalleFechaabono('d/m/Y') ?></td>
+                            <td><?php echo $entity->getAbonoproveedordetalleTipo() ?></td>
+                            <td><?php echo $entity->getAbonoproveedordetalleCantidad() ?></td>
+                            <td><?php echo $entity->getAbonoproveedordetalleMediodepago() . " ";if ($entity->getAbonoproveedordetalleMediodepago() == 'cheque') { ?><span class="label label-sm label-<?php echo $class ?>"> <?php echo $cobrado ?> </span><?php } ?></td>
+                            <td><?php echo $entity->getAbonoproveedordetalleReferencia() ?></td>
+                            <td><?php echo ($entity->getAbonoproveedordetalleComprobante() != null) ? '<a target="_blank" href="' . $entity->getAbonoproveedordetalleComprobante() . '"><i class="fa fa-file"></i></a>' : " "; ?></td>
+                        </tr>                            
+                    <?php endforeach; ?>
                 </tbody>
             </table>
             </div>

--- a/module/AERSA/view/application/flujoefectivo/cuentaporcobrar/movimientos.phtml
+++ b/module/AERSA/view/application/flujoefectivo/cuentaporcobrar/movimientos.phtml
@@ -1,3 +1,9 @@
+<style>
+    input[type=file]{
+        padding-top: 0px;
+        padding-left: 0px;
+    }
+</style>
 <link href="/application/global/plugins/datatables/datatables.min.css" rel="stylesheet" type="text/css" />
 <link href="/application/global/plugins/datatables/plugins/bootstrap/datatables.bootstrap.css" rel="stylesheet" type="text/css" />
 <link rel="stylesheet" type="text/css" href="/application/custom/css/validaciones.css">
@@ -26,6 +32,12 @@
         <div class="portlet-body form">
             <div class="form-body">
                 <div class="row">
+                    <?php
+                    $form->setAttribute('action', '/flujoefectivo/cuentaporcobrar/movimientos/'.$cuentaporcobrar->getIdcuentaporcobrar());
+                    $form->setAttribute('method','post');
+                    $form->setAttribute('enctype','multipart/form-data');
+                    echo $this->form()->openTag($form);
+                    ?>
                     <div class="col-md-6">
                         <?php echo $this->formLabel($form->get('cuentaporcobrar_fecha')); ?>  
                         <?php echo $this->formText($form->get('cuentaporcobrar_fecha')); ?>
@@ -50,10 +62,40 @@
                     <div class="col-md-6">
                         <?php echo $this->formLabel($form->get('cuentaporcobrar_comprobante')); ?>
                         <br>
-                        <?php echo '<a target="_blank" href="'.$cuentaporcobrar->getCuentaporcobrarComprobante().'"><i class="fa fa-file"></i></a>'?>
+                        <div class="col-md-1">
+                        <?php echo '<a target="_blank" href="'.$cuentaporcobrar->getCuentaporcobrarComprobante().'"><i class="fa fa-file"></i></a>'; ?>
+                        </div>
+                        <div class="col-md-11">
+                        <?php echo $this->formFile($form->get('cuentaporcobrar_comprobante'));?>
+                        </div>
                     </div>
-                    <?php endif;?>
-                </div>
+                    <?php else: ?>
+                    <div class="col-md-6">
+                        <?php echo $this->formLabel($form->get('cuentaporcobrar_comprobante')); ?>
+                        <?php echo $this->formFile($form->get('cuentaporcobrar_comprobante')); ?>
+                    </div>
+                    <?php endif; ?>
+                    <br>
+                    <div class="col-md-12">
+                        <p>(*)Campos obligatorios</p>
+                    </div>    
+                    </div>
+                    
+                    <div class="row">
+                    
+                    
+                    <div class="form-actions right">
+                        <button class="btn blue" id="plantilla_save" type="submit">
+                            <i class="fa fa-check"></i>
+                            Guardar
+                        </button>
+                    </div>
+                        </div>
+                    <?php
+                    echo $this->form()->closeTag($form);
+                    ?>
+                    
+                
                 <br><br>
                 <?php if(!(bool)$cuentaporcobrar->getCuentaporcobrarEstatuspago()):?>
                 <div class="btn-set pull-right">

--- a/public/application/custom/js/flujoefectivo/cuentabancaria.js
+++ b/public/application/custom/js/flujoefectivo/cuentabancaria.js
@@ -98,6 +98,17 @@
         }
 
         plugin.new = function () {
+            $('input[name=cuentabancaria_balance]').on('blur', function () {
+                var $this = $(this);
+                $this.removeClass('valid');
+                if ($this.val() < 0) {
+                    alert('No se aceptan numeros negativos');
+                    $this.val("");
+                } else {
+                    $this.addClass('valid');
+                }
+            });
+            
             var validarcuenta = function () {
                 var cuenta = $('input[name=cuentabancaria_nocuenta]').val();
                 var banco = $('input[name=cuentabancaria_banco]').val();

--- a/public/application/custom/js/flujoefectivo/cuentaporcobrar.js
+++ b/public/application/custom/js/flujoefectivo/cuentaporcobrar.js
@@ -58,9 +58,9 @@
 
 
         }
-        
+
         plugin.list = function () {
-            
+
             var table = $container.find('#datatable');
             $.ajax({
                 url: '/application/json/datatable/lang_es.json',
@@ -75,19 +75,39 @@
         }
 
         plugin.new = function () {
-            
+
             container.find('input[name=cuentaporcobrar_fecha]').datepicker({
                 format: 'dd/mm/yyyy',
             });
-            
+
             $('input[name=cuentaporcobrar_cantidad]').numeric();
+            $('input[name=cuentaporcobrar_cantidad]').on('blur', function () {
+                var $this = $(this);
+                $this.removeClass('valid');
+                if ($this.val() < 0) {
+                    alert('No se aceptan numeros negativos');
+                    $this.val("");
+                } else {
+                    $this.addClass('valid');
+                }
+            });
         }
-        
+
         plugin.movimientos = function () {
+            $('input[name=cuentaporcobrar_cantidad]').on('blur', function () {
+                var $this = $(this);
+                $this.removeClass('valid');
+                if ($this.val() < 0) {
+                    alert('No se aceptan numeros negativos');
+                    $this.val("");
+                } else {
+                    $this.addClass('valid');
+                }
+            });
             container.find('input[name=cuentaporcobrar_fecha]').datepicker({
                 format: 'dd/mm/yyyy',
             });
-            
+
             var table = $container.find('#datatable');
             $.ajax({
                 url: '/application/json/datatable/lang_es.json',
@@ -99,87 +119,97 @@
                     });
                 },
             });
-            
+            if (document.getElementById('datatable').getElementsByTagName("tr").length > 1) {
+                $container.find('input,select').attr('disabled', true);
+                $container.find('#plantilla_save').attr('disabled', true);
+            }
+
             $container.find('input[name=cuentaporcobrar_abonado]').attr('disabled', true);
-            
-            $('.editarmovimiento').click(function(){
-              var id = $(this).closest('tr').attr('id');
-              var tmpl = [
-                // tabindex is required for focus
-                ' <div class="modal fade draggable-modal" id="draggable" tabindex="-1" role="basic" aria-hidden="true">',
-                  '<div class="modal-header">',
+
+            $('.editarmovimiento').click(function () {
+                var id = $(this).closest('tr').attr('id');
+                var tmpl = [
+                    // tabindex is required for focus
+                    ' <div class="modal fade draggable-modal" id="draggable" tabindex="-1" role="basic" aria-hidden="true">',
+                    '<div class="modal-header">',
                     '<button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>',
-                    '<h4 class="modal-title">EDITAR MOVIMIENTO</h4>', 
-                  '</div>',
-                  '<form method="post" action="/flujoefectivo/cuentaporcobrar/editarmovimiento/'+id+'">',
+                    '<h4 class="modal-title">EDITAR MOVIMIENTO</h4>',
+                    '</div>',
+                    '<form method="post" action="/flujoefectivo/cuentaporcobrar/editarmovimiento/' + id + '">',
                     '<div class="modal-body">',
-                        '<div class="row">',
-                            '<div class="form-group">',
-                                '<div class="col-md-6">',
-                                    '<label for="flujoefectivo_chequecirculacion">¿Cobrado?</label>',
-                                    '<select class="form-control" name="flujoefectivo_chequecirculacion">',
-                                        '<option value="0">No</option>',
-                                        '<option value="1">SI</option>',
-                                    '</select>',
-                                '</div>',
-                                '<div class="col-md-6">',
-                                    '<label for="flujoefectivo_fechacobrocheque">Fecha de cobro</label>',
-                                    '<input class="form-control" type="text" value="" disabled="disabled" name="flujoefectivo_fechacobrocheque">',
-                                '</div>',
-                            '</div>',
-                        '</div>',
+                    '<div class="row">',
+                    '<div class="form-group">',
+                    '<div class="col-md-6">',
+                    '<label for="flujoefectivo_chequecirculacion">¿Cobrado?</label>',
+                    '<select class="form-control" name="flujoefectivo_chequecirculacion">',
+                    '<option value="0">No</option>',
+                    '<option value="1">SI</option>',
+                    '</select>',
+                    '</div>',
+                    '<div class="col-md-6">',
+                    '<label for="flujoefectivo_fechacobrocheque">Fecha de cobro</label>',
+                    '<input class="form-control" type="text" value="" disabled="disabled" name="flujoefectivo_fechacobrocheque">',
+                    '</div>',
+                    '</div>',
+                    '</div>',
                     '</div>',
                     '<div class="modal-footer">',
-                      '<a href="#" data-dismiss="modal" class="btn btn-default">Cancelar</a>',
-                      '<button disabled class="btn blue" type="submit">Guardar</button>',
+                    '<a href="#" data-dismiss="modal" class="btn btn-default">Cancelar</a>',
+                    '<button disabled class="btn blue" type="submit">Guardar</button>',
                     '</div>',
-                  '</form>',
-                '</div>'
-              ].join('');
-              var $modal = $(tmpl);
-              $modal.modal();
-              $modal.find('input').datepicker({
-                format: 'dd/mm/yyyy',
+                    '</form>',
+                    '</div>'
+                ].join('');
+                var $modal = $(tmpl);
+                $modal.modal();
+                $modal.find('input').datepicker({
+                    format: 'dd/mm/yyyy',
                 });
-              $modal.find('select[name=flujoefectivo_chequecirculacion]').on('change',function(){
-                  var value = $modal.find('select[name=flujoefectivo_chequecirculacion] option:selected').val();
-                  if(value == 1){
-                      $modal.find('input[name=flujoefectivo_fechacobrocheque]').prop('disabled',false).prop('required',true);
-                      $modal.find('button').prop('disabled',false);
-                  }else{
-                      $modal.find('input[name=flujoefectivo_fechacobrocheque]').prop('disabled',true).prop('required',false);
-                      $modal.find('button').prop('disabled',true);
-                  }
-              });
-              
+                $modal.find('select[name=flujoefectivo_chequecirculacion]').on('change', function () {
+                    var value = $modal.find('select[name=flujoefectivo_chequecirculacion] option:selected').val();
+                    if (value == 1) {
+                        $modal.find('input[name=flujoefectivo_fechacobrocheque]').prop('disabled', false).prop('required', true);
+                        $modal.find('button').prop('disabled', false);
+                    } else {
+                        $modal.find('input[name=flujoefectivo_fechacobrocheque]').prop('disabled', true).prop('required', false);
+                        $modal.find('button').prop('disabled', true);
+                    }
+                });
+
             });
         }
-        
+
         plugin.pago = function (resta) {
-            
-            
+
+
             container.find('input[name=flujoefectivo_fecha]').datepicker({
                 format: 'dd/mm/yyyy',
             });
-            
+
             container.find('input[name=flujoefectivo_fechacobrocheque]').datepicker({
                 format: 'dd/mm/yyyy',
             });
-            
+
             $('input[name=flujoefectivo_cantidad]').numeric();
-            
-            $('input[name=flujoefectivo_cantidad]').on('blur' , function () {
-                var $this=$(this);
+
+            $('input[name=flujoefectivo_cantidad]').on('blur', function () {
+                var $this = $(this);
                 $this.removeClass('valid');
-                if($this.val()>resta) {
+                if ($this.val() > resta) {
                     alert('Cantidad excede el restante');
                     $this.val("");
                 } else {
-                    $this.addClass('valid');
+                    if ($this.val() < 0) {
+                        alert('No se aceptan numeros negativos');
+                        $this.val("");
+                    } else {
+                        $this.addClass('valid');
+                    }
                 }
-                    
+
+
             });
-            
+
             $container.find('select[name=flujoefectivo_mediodepago]').on('change', function () {
                 var selected = $container.find('select[name=flujoefectivo_mediodepago] option:selected');
                 selected = $(selected).val();
@@ -207,7 +237,7 @@
                 }
 
             });
-            
+
             $container.find('select[name=flujoefectivo_chequecirculacion]').on('change', function () {
                 var selected = $container.find('select[name=flujoefectivo_chequecirculacion] option:selected');
                 selected = $(selected).val();

--- a/public/application/custom/js/flujoefectivo/saldoproveedores.js
+++ b/public/application/custom/js/flujoefectivo/saldoproveedores.js
@@ -155,6 +155,17 @@
         }
 
         plugin.abono = function () {
+            $('input[name=abonoproveedordetalle_cantidad]').on('blur', function () {
+                var $this = $(this);
+                $this.removeClass('valid');
+                if ($this.val() < 0) {
+                    alert('No se aceptan numeros negativos');
+                    $this.val("");
+                } else {
+                    $this.addClass('valid');
+                }
+            });
+            
             $('input[name=abonoproveedordetalle_referencia]').on('blur',function(){
                 var referencia = $(this).val();
                 var $this = $(this);


### PR DESCRIPTION
cuentas por cobrar movimientos
- cantidad negativas. Favor de corregirlo, no se debe de permitir colocar cantidad negativas. 
- poner el botón pagos como desbloqueado al no completar la cantidad. Favor de poner esta funcionalidad al implementar la eliminación de movimientos

Cuenta por cobrar entidad
- Cantidad negativas. Favor de corregirlo, no se debe de permitir colocar cantidad negativas.
Ademas en saldo proveedor, pagos, abonos no tenia la validacion de numeros negativos.