### PR TITLE
bugs de cierre semana

### DIFF
--- a/module/AERSA/src/Application/Auditoria/Controller/CierresinventariosController.php
+++ b/module/AERSA/src/Application/Auditoria/Controller/CierresinventariosController.php
@@ -175,13 +175,13 @@ class CierresinventariosController extends AbstractActionController {
             $objcompras = \CompraQuery::create()->filterByCompraFechacompra(array('min' => $inicio_semana, 'max' => $fin_semana))->filterByIdempresa($idempresa)->filterByIdsucursal($idsucursal)->find();
             $objventas = \VentaQuery::create()->filterByVentaFechaventa(array('min' => $inicio_semana, 'max' => $fin_semana))->filterByIdsucursal($idsucursal)->find();
 
-            $objrequisicionesOrigen = \RequisicionQuery::create()->filterByRequisicionFecha(array('min' => $inicio_semana, 'max' => $fin_semana))->filterByIdalmacenorigen($idalmacen)->find();
-            $objordentabOrigen = \OrdentablajeriaQuery::create()->filterByOrdentablajeriaFecha(array('min' => $inicio_semana, 'max' => $fin_semana))->filterByIdalmacenorigen($idalmacen)->find();
+            $objrequisicionesOrigen = \RequisicionQuery::create()->filterByRequisicionFecha(array('min' => $inicio_semana, 'max' => $fin_semana))->filterByIdalmacenorigen($idalmacen)->filterByIdsucursalorigen($idsucursal)->find();
+            $objordentabOrigen = \OrdentablajeriaQuery::create()->filterByOrdentablajeriaFecha(array('min' => $inicio_semana, 'max' => $fin_semana))->filterByIdalmacenorigen($idalmacen)->filterByIdsucursal($idsucursal)->find();
 
-            $objrequisicionesDestino = \RequisicionQuery::create()->filterByRequisicionFecha(array('min' => $inicio_semana, 'max' => $fin_semana))->filterByIdalmacendestino($idalmacen)->find();
-            $objordentabDestino = \OrdentablajeriaQuery::create()->filterByOrdentablajeriaFecha(array('min' => $inicio_semana, 'max' => $fin_semana))->filterByIdalmacendestino($idalmacen)->find();
+            $objrequisicionesDestino = \RequisicionQuery::create()->filterByRequisicionFecha(array('min' => $inicio_semana, 'max' => $fin_semana))->filterByIdalmacendestino($idalmacen)->filterByIdsucursaldestino($idsucursal)->find();
+            $objordentabDestino = \OrdentablajeriaQuery::create()->filterByOrdentablajeriaFecha(array('min' => $inicio_semana, 'max' => $fin_semana))->filterByIdalmacendestino($idalmacen)->filterByIdsucursal($idsucursal)->find();
 
-            $objdevoluciones = \DevolucionQuery::create()->filterByDevolucionFechadevolucion(array('min' => $inicio_semana, 'max' => $fin_semana))->filterByIdsucursal($idsucursal)->find();
+            $objdevoluciones = \DevolucionQuery::create()->filterByDevolucionFechadevolucion(array('min' => $inicio_semana, 'max' => $fin_semana))->filterByIdsucursal($idsucursal)->filterByIdalmacen($idalmacen)->find();
 
 
 

--- a/module/AERSA/src/Application/Auditoria/Controller/CierresinventariosController.php
+++ b/module/AERSA/src/Application/Auditoria/Controller/CierresinventariosController.php
@@ -100,6 +100,7 @@ class CierresinventariosController extends AbstractActionController {
         $ts = strtotime("now");
         $start = (date('w', $ts) == 0) ? $ts : strtotime('last monday', $ts);
         //dia inicio de semana date('Y-m-d',$start);
+        
         $semana_act = \SucursalQuery::create()->filterByIdsucursal($idsucursal)->findOne()->getSucursalMesactivo();
         $anio_act = \SucursalQuery::create()->filterByIdsucursal($idsucursal)->findOne()->getSucursalAnioactivo();
         $time = strtotime("1 January $anio_act", time());
@@ -143,17 +144,29 @@ class CierresinventariosController extends AbstractActionController {
                     if ($producto['CLAVE'] != 'CLAVE' && (count($producto) == 6 || count($producto) == 5))
                         $productosReporte[$producto['CLAVE']] = $producto['TOTAL'];
             }
-            $ts = strtotime("now");
-            $start = (date('w', $ts) == 0) ? $ts : strtotime('last monday', $ts);
-            $inicio_semana = date('Y-m-d', $start);
-            $fin_semana = date('Y-m-d', strtotime('next sunday', $start));
+            
+            
+            $semana_act = \SucursalQuery::create()->filterByIdsucursal($idsucursal)->findOne()->getSucursalMesactivo();
+            $anio_act = \SucursalQuery::create()->filterByIdsucursal($idsucursal)->findOne()->getSucursalAnioactivo();
+            $time = strtotime("1 January $anio_act", time());
+            $day = date('w', $time);
+            $time += ((7 * $semana_act) + 1 - $day) * 24 * 3600;
+            $time += 6 * 24 * 3600;
+            $fecha = date('Y-m-d', $time);
+            
+            $start=strtotime('last monday', $time);
+            $inicio_semana = date('Y-m-d', strtotime('last monday', $time));
+            
+            $fin_semana = date('Y-m-d', $time);
 
             $fin_semana_anterior = date('Y-m-d', strtotime('last sunday', $start));
             $fin_semana_anterior = $fin_semana_anterior . " 23:59:59";
 
+            
             $inicio_semana = $inicio_semana . " 00:00:00   ";
             $fin_semana = $fin_semana . " 23:59:59";
 
+            
             //inventario anterior
             $inventario_anterior = \InventariomesQuery::create()->filterByInventariomesFecha($fin_semana_anterior)->filterByIdalmacen($idalmacen)->exists();
             if ($inventario_anterior)
@@ -504,7 +517,6 @@ class CierresinventariosController extends AbstractActionController {
                         echo $R->render('excel');
                     exit();
                 } else {
-                    //$post_data["requisicion_fecha"] = date_create_from_format('d/m/Y', $post_data["requisicion_fecha"]);
                     foreach ($post_data as $key => $value) {
                         if (\InventariomesPeer::getTableMap()->hasColumn($key)) {
                             $inventariomes->setByName($key, $value, \BasePeer::TYPE_FIELDNAME);

--- a/module/AERSA/src/Application/Reportes/Controller/CardexController.php
+++ b/module/AERSA/src/Application/Reportes/Controller/CardexController.php
@@ -34,7 +34,6 @@ class CardexController extends AbstractActionController {
             }
             $reporte = array();
             foreach ($post_data['almacenes'] as $idalmacen) {
-                echo "entro";
                 $inicioSpli = explode('/', $post_data['inicio']);
                 $finSpli = explode('/', $post_data['fin']);
 


### PR DESCRIPTION
#### Si existe un registro de inventariocierresemana del almacen seleccionado (de la semana previa a la semana activa)
* el inventarioinicial es igual al stockfisico
 * En el batch se estaba tomando mal la fecha activa por lo cual no existia un cierre semana previo y mostraba datos erróneos 
* Actualmente, está tomando el inventarioinicial del último registro de inventariocierresemana (aunque este registro pertenezca a la misma semana que el registro que se está realizando)
 * En el batch se estaba tomando mal la fecha activa por lo cual no existia un cierre semana previo y mostraba datos erróneos 

#### Si no existe un registro de inventariocierresemana del almacén seleccionado 
* el inventarioinicial es = 0
 * En el batch se estaba tomando mal la fecha activa por lo cual no existia un cierre semana previo y mostraba datos erróneos 

#### Los movimientos de: cmpr, reqing, ordtabing, vnt, reqeg, ordtabeg, dev se deben de validar que correspondan al almacén que fue seleccionado. 
* Veo de mi lado que ya se esta validando el almacen, veo que falto validar la sucursal, ya se ha realizado el filtro 

#### Listar los movimientos de: cmpr, reqing, ordtabing, vnt, reqeg, ordtabeg, dev, al momento no se lista ninguno
* Veo de mi lado que ya se esta validando el almacen, veo que falto validar la sucursal, ya se ha realizado el filtro 

#### Los movimientos deben de corresponder al periodo que contempla la semana activa de la sucursal en la que se está loggeado
* Veo de mi lado que ya se esta validando el almacen, veo que falto validar la sucursal, ya se ha realizado el filtro 

#### No está tomando en cuenta la semana activa para setear la fecha del inventariocierresemana
* CDK->Chapalita 26 de sept - 2 oct
 * De mi lado funciona correctamente
* el inventariocierresemana está tomando en cuenta la fecha del 3 al 9 de octubre
 * Esto se debía a la semana activa incorrecta en el batch